### PR TITLE
Implement versioning support in CLI tool

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -25,6 +25,7 @@ builds:
     ldflags:
       - -s -w -X main.version={{.Version}} -X main.commit={{.Commit}} -X main.date={{.Date}}
     main: .
+    binary: testrigor-ci
 
 archives:
   - formats: [ 'tar.gz' ]

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -10,11 +10,25 @@ import (
 
 var (
 	cfgFile string
+	Version string
+	Commit  string
+	Date    string
+
 	rootCmd = &cobra.Command{
 		Use:   "testrigor",
 		Short: "A CLI tool for managing TestRigor test suite runs",
 		Long: `A command line utility for managing TestRigor test suite runs.
 It supports configuration through environment variables, command line flags, and a config file.`,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			// If version flag is set, print version and exit
+			if cmd.Flag("version").Changed {
+				fmt.Fprintf(cmd.OutOrStdout(), "Version: %s\n", Version)
+				fmt.Fprintf(cmd.OutOrStdout(), "Commit: %s\n", Commit)
+				fmt.Fprintf(cmd.OutOrStdout(), "Build Date: %s\n", Date)
+				return nil
+			}
+			return cmd.Help()
+		},
 	}
 )
 
@@ -28,6 +42,7 @@ func init() {
 
 	// Global flags
 	rootCmd.PersistentFlags().StringVar(&cfgFile, "config", "", "config file (default is $HOME/.testrigor.yaml)")
+	rootCmd.Flags().Bool("version", false, "Print version information and exit")
 
 	// Add commands
 	rootCmd.AddCommand(runCmd)

--- a/cmd/root_test.go
+++ b/cmd/root_test.go
@@ -1,0 +1,81 @@
+package cmd
+
+import (
+	"bytes"
+	"fmt"
+	"testing"
+
+	"github.com/spf13/cobra"
+	"github.com/stretchr/testify/assert"
+)
+
+// resetCommand resets the command state for testing
+func resetCommand() {
+	rootCmd = &cobra.Command{
+		Use:   "testrigor",
+		Short: "A CLI tool for managing TestRigor test suite runs",
+		Long: `A command line utility for managing TestRigor test suite runs.
+It supports configuration through environment variables, command line flags, and a config file.`,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			// If version flag is set, print version and exit
+			if cmd.Flag("version").Changed {
+				fmt.Fprintf(cmd.OutOrStdout(), "Version: %s\n", Version)
+				fmt.Fprintf(cmd.OutOrStdout(), "Commit: %s\n", Commit)
+				fmt.Fprintf(cmd.OutOrStdout(), "Build Date: %s\n", Date)
+				return nil
+			}
+			return cmd.Help()
+		},
+	}
+	rootCmd.Flags().Bool("version", false, "Print version information and exit")
+
+	// Add subcommands
+	rootCmd.AddCommand(runCmd)
+	rootCmd.AddCommand(statusCmd)
+	rootCmd.AddCommand(cancelCmd)
+	rootCmd.AddCommand(runAndWaitCmd)
+}
+
+func TestVersionFlag(t *testing.T) {
+	// Reset command state
+	resetCommand()
+
+	// Set test version information
+	Version = "1.2.3"
+	Commit = "abc123"
+	Date = "2024-03-20"
+
+	// Create a buffer to capture output
+	var buf bytes.Buffer
+	rootCmd.SetOut(&buf)
+	rootCmd.SetErr(&buf)
+	rootCmd.SetArgs([]string{"--version"})
+
+	err := rootCmd.Execute()
+	assert.NoError(t, err)
+
+	// Check output contains version information
+	output := buf.String()
+	assert.Contains(t, output, "Version: 1.2.3")
+	assert.Contains(t, output, "Commit: abc123")
+	assert.Contains(t, output, "Build Date: 2024-03-20")
+}
+
+func TestHelpOutput(t *testing.T) {
+	// Reset command state
+	resetCommand()
+
+	// Create a buffer to capture output
+	var buf bytes.Buffer
+	rootCmd.SetOut(&buf)
+	rootCmd.SetErr(&buf)
+	rootCmd.SetArgs([]string{})
+
+	err := rootCmd.Execute()
+	assert.NoError(t, err)
+
+	// Check output contains help information
+	output := buf.String()
+	assert.Contains(t, output, "Usage:")
+	assert.Contains(t, output, "Available Commands:")
+}

--- a/main.go
+++ b/main.go
@@ -7,9 +7,20 @@ import (
 	"github.com/benvon/testrigor-ci-tool/cmd"
 )
 
+var (
+	version string
+	commit  string
+	date    string
+)
+
 func main() {
+	// Set version information in the root command
+	cmd.Version = version
+	cmd.Commit = commit
+	cmd.Date = date
+
 	if err := cmd.Execute(); err != nil {
 		fmt.Fprintln(os.Stderr, err)
 		os.Exit(1)
 	}
-} 
+}


### PR DESCRIPTION
- Added version, commit, and build date variables to the main application.
- Updated the root command to print version information when the --version flag is used.
- Introduced unit tests for version flag functionality and help output in root_test.go.
- Configured GoReleaser to specify the binary name for builds.