### PR TITLE
Enhance error handling for test crashes in API client

### DIFF
--- a/internal/api/testrigor_test.go
+++ b/internal/api/testrigor_test.go
@@ -585,7 +585,54 @@ func TestWaitForTestCompletion(t *testing.T) {
 			errors:         []error{fmt.Errorf("test failed")},
 			timeoutMinutes: 1,
 			wantErr:        true,
-			errMsg:         "test run failed",
+			errMsg:         "error making request: test failed",
+		},
+		{
+			name: "test crash in results",
+			statuses: []map[string]interface{}{
+				{
+					"status": "failed",
+					"overallResults": map[string]interface{}{
+						"Total":       1,
+						"In queue":    0,
+						"In progress": 0,
+						"Failed":      0,
+						"Passed":      0,
+						"Not started": 0,
+						"Canceled":    0,
+						"Crash":       1,
+					},
+				},
+			},
+			errors:         []error{nil},
+			timeoutMinutes: 1,
+			wantErr:        true,
+			errMsg:         "test crashed: 1 test(s) crashed",
+		},
+		{
+			name: "test crash in error message",
+			statuses: []map[string]interface{}{
+				{
+					"status": "failed",
+					"overallResults": map[string]interface{}{
+						"Total":       1,
+						"In queue":    0,
+						"In progress": 0,
+						"Failed":      0,
+						"Passed":      0,
+						"Not started": 0,
+						"Canceled":    0,
+						"Crash":       0,
+					},
+					"errors": []interface{}{
+						"CRASH: API call to 'https://development-eu01-kontoor.demandware.net/s/-/dw/data/v20_4/inventory_lists/wrangler/product_inventory_records/112362911:S' returned HTTP code '404' but expected code is '200'",
+					},
+				},
+			},
+			errors:         []error{nil},
+			timeoutMinutes: 1,
+			wantErr:        true,
+			errMsg:         "test crashed: CRASH: API call to 'https://development-eu01-kontoor.demandware.net/s/-/dw/data/v20_4/inventory_lists/wrangler/product_inventory_records/112362911:S' returned HTTP code '404' but expected code is '200'",
 		},
 	}
 

--- a/internal/api/utils/utils.go
+++ b/internal/api/utils/utils.go
@@ -73,8 +73,8 @@ func HandleStatusCheckError(err error, consecutiveErrors *int, maxConsecutiveErr
 		}
 		return true, nil
 	}
-	if strings.Contains(err.Error(), "test failed") {
-		return false, fmt.Errorf("test run failed")
+	if strings.Contains(err.Error(), "test failed") || strings.Contains(err.Error(), "test crashed:") {
+		return false, err
 	}
 	return false, err
 }


### PR DESCRIPTION
- Updated the `handleResponse` method to differentiate between standard API errors and test crash errors, providing more specific error messages.
- Added new test cases in `testrigor_test.go` to validate the handling of test crashes and ensure accurate error reporting.
- Improved the `GetTestStatus` and `WaitForTestCompletion` methods to check for crash conditions and return appropriate error messages.
- Modified the `HandleStatusCheckError` function to handle both test failure and crash scenarios more effectively.