### PR TITLE
ci: fix dependabot release policy checks

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,7 +10,7 @@ updates:
       - "dependencies"
       - "go"
     commit-message:
-      prefix: "go"
+      prefix: "chore"
       include: "scope"
 
   # Enable version updates for GitHub Actions
@@ -23,5 +23,5 @@ updates:
       - "dependencies"
       - "github-actions"
     commit-message:
-      prefix: "github-actions"
-      include: "scope" 
+      prefix: "chore"
+      include: "scope"

--- a/.github/workflows/release-policy.yml
+++ b/.github/workflows/release-policy.yml
@@ -7,10 +7,10 @@ on:
 permissions:
   contents: read
   issues: write
-  pull-requests: read
+  pull-requests: write
 
 jobs:
   release-policy:
-    uses: benvon/reusable-workflows/.github/workflows/release-policy.yml@0a878c63c5a17372ecd27a1fd1fffd7c1b88e5d3
+    uses: benvon/reusable-workflows/.github/workflows/release-policy.yml@f70796de0a6527dbed267a64835c3cc81b8144e0
     with:
       pull_request_number: ${{ github.event.pull_request.number }}


### PR DESCRIPTION
## Summary
- update Dependabot commit-message prefixes to use conventional commit titles
- update the release-policy caller workflow to use the newer reusable workflow revision
- grant pull-request write permission so the reusable workflow can sync release labels on Dependabot PRs

## Testing
- validate both workflow YAML files parse with Ruby YAML
- verify the commit is signed